### PR TITLE
remove development environment from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       run:
         shell: bash
     runs-on: ${{ matrix.os }}
-    environment: development
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4


### PR DESCRIPTION
ci.yml only runs on main branch. it should run ci withour waiting development environment approval.