### PR TITLE
fix mypy not detect pytest in dev ci

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -34,7 +34,7 @@ jobs:
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root --without test --with docs
+        run: poetry install --no-interaction --no-root --with docs
       - name: Activate virtual environment
         run: source $VENV
       - name: Lint with Ruff


### PR DESCRIPTION
mypy require pytest (test dependency) to be installed in order to perform static type analysis, hence it raise error if pytest dependency not installed. to fix this, we just need to include the test dependency.